### PR TITLE
Modifica document_doi

### DIFF
--- a/scielo_scholarly_data/standardizer.py
+++ b/scielo_scholarly_data/standardizer.py
@@ -196,16 +196,17 @@ def document_doi(text: str, return_mode='uri'):
         path: 10.1038/nphys1170.
         host: dx.doi.org.
     """
-    matched_doi = True
+    matched_doi = False
     for pattern_doi in PATTERNS_DOI:
         matched_doi = pattern_doi.search(text)
+        if matched_doi:
+            break
     if not matched_doi:
         return {'error' : 'invalid doi'}
-    d = urlparse(text)
-    if return_mode == 'uri' and d.scheme != '' and (d.scheme == 'http' or d.scheme == 'https' or d.scheme == 'ftp'):
-        return d.scheme + '://' + d.netloc + d.path
+    if return_mode == 'uri':
+        return f'http://doi.org/{matched_doi.group()}'
     if return_mode == 'host':
-        return d.netloc
+        return 'doi.org'
     if return_mode == 'path':
         return matched_doi.group()
 

--- a/scielo_scholarly_data/values.py
+++ b/scielo_scholarly_data/values.py
@@ -10,7 +10,8 @@ PATTERNS_DOI = [re.compile(pd) for pd in [
     r'10.\d{4,9}/[-._;()/:A-Z0-9]+$',
     r'10.1002/[^\s]+$',
     r'10.\d{4}/\d+-\d+X?(\d+)\d+<[\d\w]+:[\d\w]*>\d+.\d+.\w+;\d$',
-    r'10.1207/[\w\d]+\&\d+_\d+$']
+    r'10.1207/[\w\d]+\&\d+_\d+$',
+    r'10.\d{4,9}/[-._;()/:a-zA-Z0-9]*']
 ]
 
 # https://en.wikipedia.org/wiki/International_Standard_Serial_Number (accessed on 2021/08/31)

--- a/tests/test_standardizer.py
+++ b/tests/test_standardizer.py
@@ -164,7 +164,7 @@ class TestStandardizer(unittest.TestCase):
 
         self.assertListEqual(expected_values, obtained_values)
 
-    def test_document_doi(self):
+    def test_document_doi_return_mode_path(self):
         dois = {
             'https://10.1016/J.SCITOTENV.2019.02.108': '10.1016/J.SCITOTENV.2019.02.108',
             'http://10.1007/S13157-019-01161-Y': '10.1007/S13157-019-01161-Y',
@@ -175,7 +175,37 @@ class TestStandardizer(unittest.TestCase):
         }
 
         expected_values = list(dois.values())
-        obtained_values = [document_doi(d) for d in dois]
+        obtained_values = [document_doi(d, return_mode='path') for d in dois]
+
+        self.assertListEqual(expected_values, obtained_values)
+
+    def test_document_doi_return_mode_uri(self):
+        dois = {
+            'https://10.1016/J.SCITOTENV.2019.02.108': 'https://10.1016/J.SCITOTENV.2019.02.108',
+            'http://10.1007/S13157-019-01161-Y': 'http://10.1007/S13157-019-01161-Y',
+            '10.4257/OECO.2020.2401.05': None,
+            'ftp://10.1111/EFF.12536': 'ftp://10.1111/EFF.12536',
+            'axc; 10.1007/S10452-020-09782-W': None,
+            '&referrer=google*url=10.1590/1678-4766E2016006': None,
+        }
+
+        expected_values = list(dois.values())
+        obtained_values = [document_doi(d, return_mode='uri') for d in dois]
+
+        self.assertListEqual(expected_values, obtained_values)
+
+    def test_document_doi_return_mode_host(self):
+        dois = {
+            'https://10.1016/J.SCITOTENV.2019.02.108': '10.1016',
+            'http://10.1007/S13157-019-01161-Y': '10.1007',
+            '10.4257/OECO.2020.2401.05': '',
+            'ftp://10.1111/EFF.12536': '10.1111',
+            'axc; 10.1007/S10452-020-09782-W': '',
+            '&referrer=google*url=10.1590/1678-4766E2016006': '',
+        }
+
+        expected_values = list(dois.values())
+        obtained_values = [document_doi(d, return_mode='host') for d in dois]
 
         self.assertListEqual(expected_values, obtained_values)
 

--- a/tests/test_standardizer.py
+++ b/tests/test_standardizer.py
@@ -181,12 +181,12 @@ class TestStandardizer(unittest.TestCase):
 
     def test_document_doi_return_mode_uri(self):
         dois = {
-            'https://10.1016/J.SCITOTENV.2019.02.108': 'https://10.1016/J.SCITOTENV.2019.02.108',
-            'http://10.1007/S13157-019-01161-Y': 'http://10.1007/S13157-019-01161-Y',
-            '10.4257/OECO.2020.2401.05': None,
-            'ftp://10.1111/EFF.12536': 'ftp://10.1111/EFF.12536',
-            'axc; 10.1007/S10452-020-09782-W': None,
-            '&referrer=google*url=10.1590/1678-4766E2016006': None,
+            'https://10.1016/J.SCITOTENV.2019.02.108': 'http://doi.org/10.1016/J.SCITOTENV.2019.02.108',
+            'http://10.1007/S13157-019-01161-Y': 'http://doi.org/10.1007/S13157-019-01161-Y',
+            '10.4257/OECO.2020.2401.05': 'http://doi.org/10.4257/OECO.2020.2401.05',
+            'ftp://10.1111/EFF.12536': 'http://doi.org/10.1111/EFF.12536',
+            'axc; 10.1007/S10452-020-09782-W': 'http://doi.org/10.1007/S10452-020-09782-W',
+            '&referrer=google*url=10.1590/1678-4766E2016006': 'http://doi.org/10.1590/1678-4766E2016006',
         }
 
         expected_values = list(dois.values())
@@ -196,12 +196,12 @@ class TestStandardizer(unittest.TestCase):
 
     def test_document_doi_return_mode_host(self):
         dois = {
-            'https://10.1016/J.SCITOTENV.2019.02.108': '10.1016',
-            'http://10.1007/S13157-019-01161-Y': '10.1007',
-            '10.4257/OECO.2020.2401.05': '',
-            'ftp://10.1111/EFF.12536': '10.1111',
-            'axc; 10.1007/S10452-020-09782-W': '',
-            '&referrer=google*url=10.1590/1678-4766E2016006': '',
+            'https://10.1016/J.SCITOTENV.2019.02.108': 'doi.org',
+            'http://10.1007/S13157-019-01161-Y': 'doi.org',
+            '10.4257/OECO.2020.2401.05': 'doi.org',
+            'ftp://10.1111/EFF.12536': 'doi.org',
+            'axc; 10.1007/S10452-020-09782-W': 'doi.org',
+            '&referrer=google*url=10.1590/1678-4766E2016006': 'doi.org',
         }
 
         expected_values = list(dois.values())


### PR DESCRIPTION
### O que esse PR faz?
Atualiza o método `document_doi`, flexibilizando a verificação de formato do número e adicionando diferentes valores como retorno do método. Similar ao que foi feito em `orcid_validator`

### Onde a revisão poderia começar?
Por _commit_.

### Como este poderia ser testado manualmente?
NA.

### Algum cenário de contexto que queira dar?
NA.

### Screenshots
NA.

### Quais são tickets relevantes?
#38 

### Referências
NA.