### PR TITLE
Document sponsors

### DIFF
--- a/scielo_scholarly_data/standardizer.py
+++ b/scielo_scholarly_data/standardizer.py
@@ -460,6 +460,43 @@ def document_author_for_deduplication(text: str, surname_first=True):
     return text
 
 
+def document_sponsors(text: str, remove_special_char=True):
+    """
+    Função para padronizar o nome de patrocinadores de documentos de acordo com os seguinte métodos, por ordem:
+        1. Converte códigos HTML para caracteres Unicode;
+        2. Mantém caracteres alfanuméricos e espaço;
+        3. Remove caracteres non printable;
+        4. Remove espaços duplos;
+        5. Remove pontuação no final do título;
+        6. Remove espaços nas extremidades do título;
+        7. Remove acentos;
+        8. Converte os caracteres para caixa baixa.
+
+    Parameters
+    ----------
+    text : str
+        Título do documento a ser padronizado.
+    remove_char : bool, default True
+        Valor lógico que indica se as entidades HTML e os caracteres especiais devem ser mantidos ou retirados.
+
+    Returns
+    -------
+    str
+        Título padronizado do documento.
+    """
+
+    text = unescape(text)
+    if remove_special_char:
+        text = keep_alpha_num_space(text)
+    text = remove_non_printable_chars(text)
+    text = remove_double_spaces(text)
+    text = remove_end_punctuation_chars(text)
+    text = text.strip()
+    text = remove_accents(text)
+    text = text.lower()
+    return text
+
+
 def book_title(text: str):
     pass
 

--- a/tests/test_standardizer.py
+++ b/tests/test_standardizer.py
@@ -703,3 +703,51 @@ class TestStandardizer(unittest.TestCase):
         obtained_values = [document_title_for_visualization(dt) for dt in titles]
 
         self.assertListEqual(expected_values, obtained_values)
+
+    def test_document_sponsors_html_entities_keeps(self):
+        self.assertEqual(
+            document_title_for_deduplication('Fundação de Amparo a Pesquisa do Estado de São Paulo &#60; Biota Program', remove_special_char=False),
+            'fundacao de amparo a pesquisa do estado de sao paulo < biota program'
+        )
+
+    def test_document_sponsors_keep_alpha_num_space(self):
+        self.assertEqual(
+            document_title_for_deduplication('Fundação de Amparo a Pesquisa do Estado de São Paulo &#60; Biota Program'),
+            'fundacao de amparo a pesquisa do estado de sao paulo biota program'
+        )
+
+    def test_document_sponsors_remove_non_printable_chars(self):
+        self.assertEqual(
+            document_title_for_deduplication('Fundação de Amparo a Pesquisa do \n Estado de São Paulo \t Biota Program'),
+            'fundacao de amparo a pesquisa do estado de sao paulo biota program'
+        )
+
+    def test_document_sponsors_remove_double_spaces(self):
+        self.assertEqual(
+            document_title_for_deduplication('Fundação  de   Amparo  a Pesquisa do  Estado de São Paulo  Biota Program'),
+            'fundacao de amparo a pesquisa do estado de sao paulo biota program'
+        )
+
+    def test_document_sponsors_remove_end_punctuation_chars(self):
+        self.assertEqual(
+            document_title_for_deduplication('Fundação de Amparo a Pesquisa do Estado de São Paulo Biota Program,.;'),
+            'fundacao de amparo a pesquisa do estado de sao paulo biota program'
+        )
+
+    def test_document_sponsors_text_strip(self):
+        self.assertEqual(
+            document_title_for_deduplication(' Fundação de Amparo a Pesquisa do Estado de São Paulo Biota Program '),
+            'fundacao de amparo a pesquisa do estado de sao paulo biota program'
+        )
+
+    def test_document_sponsors_remove_accents(self):
+        self.assertEqual(
+            document_title_for_deduplication('Fundação de Amparo à Pesquisa do Estado de São Paulo Biota Program'),
+            'fundacao de amparo a pesquisa do estado de sao paulo biota program'
+        )
+
+    def test_document_sponsors_text_lower(self):
+        self.assertEqual(
+            document_title_for_deduplication('Fundação de Amparo a Pesquisa do Estado de São Paulo Biota Program'),
+            'fundacao de amparo a pesquisa do estado de sao paulo biota program'
+        )


### PR DESCRIPTION
### O que esse PR faz?
Adiciona o método `document_sponsors` que executa processos de padronização para deduplicação posterior.

### Onde a revisão poderia começar?
A revisão pode seguir de acordo com os _commits_, primeiro o método, depois os testes.

### Como este poderia ser testado manualmente?
Instale como uma biblioteca:
`pip install -e git+https://github.com/scieloorg/scielo_scholarly_data#egg=scielo_scholarly_data`

Crie um ambiente virtual e instale as dependências da aplicação
```
# Create a virtual environment
virtualenv -p python3 .venv

# Access the virtual environment
source .venv/bin/activated

# Install dependencies
pip install -r requirements.txt

# Install the package
python setup.py install
```
### Algum cenário de contexto que queira dar?
NA.

### Screenshots
NA.

### Quais são tickets relevantes?
NA. 
### Referências
NA. 