### PR TITLE
Trata erro ao tentar converter data mal formada

### DIFF
--- a/scielo_scholarly_data/core.py
+++ b/scielo_scholarly_data/core.py
@@ -270,7 +270,7 @@ def convert_to_iso_date(text, day='01', month='01', only_year=False):
                         month = MONTHS_DICT[month]
                         #Tenta converter a data tratada
                         text = parse('-'.join([year, month, day])).date()
-                except (ValueError, IndexError, AttributeError):
+                except (ValueError, IndexError, AttributeError, KeyError):
                     return None
             else:
                 try:

--- a/scielo_scholarly_data/standardizer.py
+++ b/scielo_scholarly_data/standardizer.py
@@ -25,6 +25,7 @@ from scielo_scholarly_data.values import (
     PATTERN_ORCID,
     PATTERN_PAGE_RANGE,
     PUNCTUATION_TO_DEFINE_PAGE_RANGE,
+    PUNCTUATION_TO_KEEP_IN_PERSONS_NAME_VISUALIZATION,
 )
 
 from scielo_scholarly_data.helpers import is_valid_issn

--- a/scielo_scholarly_data/standardizer.py
+++ b/scielo_scholarly_data/standardizer.py
@@ -31,8 +31,6 @@ from scielo_scholarly_data.values import (
 from scielo_scholarly_data.helpers import is_valid_issn
 from urllib.parse import urlparse
 
-from urllib.parse import urlparse
-
 
 def journal_title_for_deduplication(text: str, words_to_remove=JOURNAL_TITLE_SPECIAL_WORDS,
                                     keep_parenthesis_content=True, chars_to_remove=[]):

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ install_requirements=[
 
 setup(
     name='scielo-scholarly-data',
-    version='0.1',
+    version='0.1.1',
     description="The SciELO Scholarly Data Standardizer, Normalizer and Deduplicator Tools",
     author="SciELO",
     author_email="scielo-dev@googlegroups.com",

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ install_requirements=[
 
 setup(
     name='scielo-scholarly-data',
-    version='0.1.1',
+    version='0.1.2',
     description="The SciELO Scholarly Data Standardizer, Normalizer and Deduplicator Tools",
     author="SciELO",
     author_email="scielo-dev@googlegroups.com",

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -166,6 +166,12 @@ class TestCore(unittest.TestCase):
             None
         )
 
+    def test_convert_to_iso_date_nondate_value(self):
+        self.assertEqual(
+            convert_to_iso_date('200W'),
+            None
+        )
+
     def test_check_sum_orcid(self):
         orcids = {
             '0000000925158361': True,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -13,7 +13,6 @@ from scielo_scholarly_data.core import (
 )
 
 import unittest
-from dateutil.parser import parse
 
 
 class TestCore(unittest.TestCase):

--- a/tests/test_standardizer.py
+++ b/tests/test_standardizer.py
@@ -872,6 +872,7 @@ class TestStandardizer(unittest.TestCase):
         self.assertEqual(
             book_editor_name_for_visualization('Editora da Universidade Estadual de São Paulo.,;.;'),
             'Editora da Universidade Estadual de São Paulo'
+        )
 
     def test_book_title_for_deduplication_html_entities_keeps(self):
         self.assertEqual(


### PR DESCRIPTION
### O que esse PR faz?
Este PR trata a situação em que tenta-se converter uma data mal-formada. São datas mal-formadas strings do tipo "200W", "3B", que por vezes ocorrem por falha de digitação ou de integração entre sistemas.

### Onde a revisão poderia começar?
Por commits e a partir do commit 23bb029720725b650f73b3df42ae44e37ccf89ad

### Como este poderia ser testado manualmente?
1. Instale o código-fonte do PR
2. Abra um terminal python
3. Entre com as seguintes instruções
```python
from scielo_scholarly_data import core
core.convert_to_iso_date('200W')
```
4. Observe que nenhum erro tenha ocorrido (nada é retornado)
5. Experimente informar valores de data que não são datas (ex. '3B', W300', etc). 
6. Experimente informar valores válidos e obseve as saídas experadas
7. Execute `python setup.py test` e observe que todos os testes resultaram `OK`, inclusive o novo método adicionado neste PR.

### Algum cenário de contexto que queira dar?
N/A

### Screenshots
N/A

### Quais são tickets relevantes?
#48 

### Referências
N/A